### PR TITLE
feat: support row deletions during main table import

### DIFF
--- a/unified_server
+++ b/unified_server
@@ -59,7 +59,15 @@ app.post('/upload', upload.single('csvfile'), async (req, res) => {
     if (tableName === 'casemanager') {
       await importCaseManager(filePath, tableName, res);
     } else if (tableName === 'maintable') {
-      await importMainTable(filePath, tableName, res);
+      // CSV may include an "Action" column with values like "DELETE" to remove rows
+      const summary = await importMainTable(filePath, tableName);
+      return res.send(`
+        ✅ MainTable Done!
+        Processed Rows: ${summary.processedRows}
+        Inserted/Updated: ${summary.insertedOrUpdated}
+        Deleted Rows: ${summary.deletedCount}
+        Skipped Rows: ${summary.skippedRows}
+      `);
     } else {
       fs.unlinkSync(filePath);
       return res.status(400).send('❌ Unknown table selected.');
@@ -135,10 +143,11 @@ async function importCaseManager(filePath, tableName, res) {
 }
 
 // ------------------ MAINTABLE IMPORT ------------------
-async function importMainTable(filePath, tableName, res) {
+async function importMainTable(filePath, tableName) {
   const BATCH_SIZE = 500;
-  let processedRows = 0, insertedOrUpdated = 0;
+  let processedRows = 0, insertedOrUpdated = 0, deletedCount = 0;
   const skippedRows = [];
+  const deleteIds = new Set();
 
   const result = await client.query(`
     SELECT column_name
@@ -150,45 +159,61 @@ async function importMainTable(filePath, tableName, res) {
   const tableColumns = result.rows.map(r => r.column_name).filter(c => c !== 'Visit ID');
   await client.query('BEGIN');
 
-  try {
-    let batch = [];
-    const parser = fs.createReadStream(filePath).pipe(parse(CSV_OPTS_TOLERANT));
+    try {
+      let batch = [];
+      const parser = fs.createReadStream(filePath).pipe(parse(CSV_OPTS_TOLERANT));
 
-    for await (const row of parser) {
-      processedRows++;
-      const visitId = row['Visit ID'];
-      if (!visitId) {
-        skippedRows.push({ row, reason: 'Missing Visit ID' });
-        continue;
+      for await (const row of parser) {
+        processedRows++;
+        const visitId = row['Visit ID'];
+        const action = (row['Action'] || '').toUpperCase();
+
+        if (!visitId) {
+          skippedRows.push({ row, reason: 'Missing Visit ID' });
+          continue;
+        }
+
+        if (action === 'DELETE') {
+          deleteIds.add(visitId);
+          continue; // Skip upsert for deletions
+        }
+
+        const rowData = tableColumns.map(c => toNullIfEmpty(row[c]));
+        batch.push({ visitId, rowData });
+        if (batch.length >= BATCH_SIZE) {
+          await processBatch(batch, tableName, tableColumns);
+          insertedOrUpdated += batch.length;
+          batch = [];
+        }
       }
-      const rowData = tableColumns.map(c => toNullIfEmpty(row[c]));
-      batch.push({ visitId, rowData });
-      if (batch.length >= BATCH_SIZE) {
+      if (batch.length) {
         await processBatch(batch, tableName, tableColumns);
         insertedOrUpdated += batch.length;
-        batch = [];
       }
-    }
-    if (batch.length) {
-      await processBatch(batch, tableName, tableColumns);
-      insertedOrUpdated += batch.length;
-    }
 
-    await client.query('COMMIT');
-    fs.unlinkSync(filePath);
+      if (deleteIds.size) {
+        const deleteRes = await client.query(
+          `DELETE FROM "${tableName}" WHERE "Visit ID" = ANY($1)`,
+          [Array.from(deleteIds)]
+        );
+        deletedCount = deleteRes.rowCount;
+      }
 
-    res.send(`
-      ✅ MainTable Done!
-      Processed Rows: ${processedRows} 
-      Inserted/Updated: ${insertedOrUpdated} 
-      Skipped Rows: ${skippedRows.length}
-    `);
-  } catch (err) {
-    await client.query('ROLLBACK');
-    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-    throw err;
+      await client.query('COMMIT');
+      fs.unlinkSync(filePath);
+
+      return {
+        processedRows,
+        insertedOrUpdated,
+        deletedCount,
+        skippedRows: skippedRows.length,
+      };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      throw err;
+    }
   }
-}
 
 async function processBatch(batch, tableName, tableColumns) {
   const dedupedMap = new Map();


### PR DESCRIPTION
## Summary
- handle optional `Action` column in uploads
- omit rows marked `DELETE` from upserts and delete them from the DB
- return deletion counts alongside insert/update stats

## Testing
- `node --check unified_server`


------
https://chatgpt.com/codex/tasks/task_e_68b341608560832c923ffdabfe2effe5