### PR TITLE
Handle null Visit ID during main table cleanup

### DIFF
--- a/unified_server
+++ b/unified_server
@@ -221,7 +221,7 @@ async function importMainTable(filePath, tableName) {
 
       if (dateCol && minDate && maxDate && csvVisitIds.size) {
         const cleanupRes = await client.query(
-          `DELETE FROM "${tableName}" WHERE "${dateCol}" BETWEEN $1 AND $2 AND NOT ("Visit ID" = ANY($3))`,
+          `DELETE FROM "${tableName}" WHERE "${dateCol}" BETWEEN $1 AND $2 AND ("Visit ID" IS NULL OR "Visit ID" <> ALL($3))`,
           [minDate, maxDate, Array.from(csvVisitIds)]
         );
         deletedCount += cleanupRes.rowCount;


### PR DESCRIPTION
## Summary
- ensure main-table cleanup removes rows with NULL Visit ID if their date falls within CSV date range

## Testing
- `node --check unified_server && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b351dd4408832cb8c7a96e0a58a208