### PR TITLE
Add billed AR aging CSV import with composite key upserts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>EOM Processor Upload</title>
+</head>
+<body>
+  <h1>Upload CSV</h1>
+  <form action="/upload" method="post" enctype="multipart/form-data">
+    <label for="tableName">Select Table:</label>
+    <select name="tableName" id="tableName">
+      <option value="casemanager">casemanager</option>
+      <option value="maintable">maintable</option>
+      <option value="unduplicatedpatients">unduplicatedpatients</option>
+      <option value="billed_ar_aging">billed_ar_aging</option>
+    </select>
+    <br>
+    <input type="file" name="csvfile" accept=".csv" required>
+    <button type="submit">Upload</button>
+  </form>
+</body>
+</html>

--- a/unified_server
+++ b/unified_server
@@ -44,6 +44,27 @@ const CSV_OPTS_TOLERANT = {
   skip_lines_with_error: true // ✅ silently skip broken lines
 };
 
+async function ensureBilledArAgingConstraint() {
+  const check = await client.query(`
+    SELECT tc.constraint_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.constraint_column_usage ccu
+      ON tc.constraint_name = ccu.constraint_name AND tc.table_name = ccu.table_name
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'billed_ar_aging'
+      AND tc.constraint_type = 'UNIQUE'
+      AND ccu.column_name IN ('Service Dates','Med Rec #','Invoice Num')
+    GROUP BY tc.constraint_name
+    HAVING COUNT(*) = 3
+  `);
+  if (check.rowCount === 0) {
+    await client.query(`
+      ALTER TABLE "billed_ar_aging"
+      ADD CONSTRAINT billed_ar_aging_unique UNIQUE("Service Dates", "Med Rec #", "Invoice Num")
+    `);
+  }
+}
+
 // ------------------ ROUTES ------------------
 app.post('/upload', upload.single('csvfile'), async (req, res) => {
   const tableName = req.body.tableName;
@@ -72,6 +93,15 @@ app.post('/upload', upload.single('csvfile'), async (req, res) => {
       const summary = await importUnduplicatedPatients(filePath, tableName);
       return res.send(`
         ✅ UnduplicatedPatients Done!
+        Processed Rows: ${summary.processedRows}
+        Inserted/Updated: ${summary.insertedOrUpdated}
+        Deleted Rows: ${summary.deletedCount}
+        Skipped Rows: ${summary.skippedRows}
+      `);
+    } else if (tableName === 'billed_ar_aging') {
+      const summary = await importBilledArAging(filePath, tableName);
+      return res.send(`
+        ✅ Billed AR Aging Done!
         Processed Rows: ${summary.processedRows}
         Inserted/Updated: ${summary.insertedOrUpdated}
         Deleted Rows: ${summary.deletedCount}
@@ -203,15 +233,15 @@ async function importMainTable(filePath, tableName) {
         }
 
         const rowData = tableColumns.map(c => toNullIfEmpty(row[c]));
-        batch.push({ key: visitId, rowData });
+        batch.push({ keys: [visitId], rowData });
         if (batch.length >= BATCH_SIZE) {
-          await processBatch(batch, tableName, tableColumns, 'Visit ID');
+          await processBatch(batch, tableName, tableColumns, ['Visit ID']);
           insertedOrUpdated += batch.length;
           batch = [];
         }
       }
       if (batch.length) {
-        await processBatch(batch, tableName, tableColumns, 'Visit ID');
+        await processBatch(batch, tableName, tableColumns, ['Visit ID']);
         insertedOrUpdated += batch.length;
       }
 
@@ -247,26 +277,34 @@ async function importMainTable(filePath, tableName) {
     }
   }
 
-async function processBatch(batch, tableName, tableColumns, keyColumn) {
+async function processBatch(batch, tableName, tableColumns, keyColumns) {
   const dedupedMap = new Map();
-  for (const item of batch) dedupedMap.set(item.key, item.rowData);
+  for (const item of batch) {
+    const keyString = item.keys.join('|');
+    dedupedMap.set(keyString, { keys: item.keys, rowData: item.rowData });
+  }
 
-  const dedupedBatch = Array.from(dedupedMap.entries()).map(([key, rowData]) => ({ key, rowData }));
+  const dedupedBatch = Array.from(dedupedMap.values());
 
   const values = [];
-  const placeholders = dedupedBatch.map((b, i) => {
-    const rowPlaceholders = b.rowData.map((_, j) => `$${i * (tableColumns.length + 1) + j + 2}`);
-    values.push(b.key, ...b.rowData);
-    return `($${i * (tableColumns.length + 1) + 1}, ${rowPlaceholders.join(', ')})`;
+  let paramIdx = 1;
+  const placeholders = dedupedBatch.map(b => {
+    const rowPlaceholders = [];
+    for (let i = 0; i < keyColumns.length + tableColumns.length; i++) {
+      rowPlaceholders.push(`$${paramIdx++}`);
+    }
+    values.push(...b.keys, ...b.rowData);
+    return `(${rowPlaceholders.join(', ')})`;
   });
 
-  const colNames = [`"${keyColumn}"`, ...tableColumns.map(c => `"${c}"`)];
+  const colNames = [...keyColumns.map(c => `"${c}"`), ...tableColumns.map(c => `"${c}"`)];
   const updateSet = tableColumns.map(c => `"${c}" = EXCLUDED."${c}"`);
+  const conflictCols = keyColumns.map(c => `"${c}"`).join(', ');
 
   const query = `
     INSERT INTO "${tableName}" (${colNames.join(', ')})
     VALUES ${placeholders.join(', ')}
-    ON CONFLICT ("${keyColumn}") DO UPDATE SET ${updateSet.join(', ')}
+    ON CONFLICT (${conflictCols}) DO UPDATE SET ${updateSet.join(', ')}
   `;
   await client.query(query, values);
 }
@@ -323,15 +361,15 @@ async function importUnduplicatedPatients(filePath, tableName) {
       }
 
       const rowData = tableColumns.map(c => toNullIfEmpty(row[c]));
-      batch.push({ key: mrn, rowData });
+      batch.push({ keys: [mrn], rowData });
       if (batch.length >= BATCH_SIZE) {
-        await processBatch(batch, tableName, tableColumns, 'MRN');
+        await processBatch(batch, tableName, tableColumns, ['MRN']);
         insertedOrUpdated += batch.length;
         batch = [];
       }
     }
     if (batch.length) {
-      await processBatch(batch, tableName, tableColumns, 'MRN');
+      await processBatch(batch, tableName, tableColumns, ['MRN']);
       insertedOrUpdated += batch.length;
     }
 
@@ -347,6 +385,110 @@ async function importUnduplicatedPatients(filePath, tableName) {
       const deleteExistingRes = await client.query(
         `DELETE FROM "${tableName}" WHERE "${dateColumn}" BETWEEN $1 AND $2 AND "MRN" NOT IN (SELECT unnest($3::text[]))`,
         [minDate, maxDate, Array.from(csvMrns)]
+      );
+      deletedCount += deleteExistingRes.rowCount;
+    }
+
+    await client.query('COMMIT');
+    fs.unlinkSync(filePath);
+
+    return {
+      processedRows,
+      insertedOrUpdated,
+      deletedCount,
+      skippedRows: skippedRows.length,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    throw err;
+  }
+}
+
+// ------------------ BILLED AR AGING IMPORT ------------------
+async function importBilledArAging(filePath, tableName) {
+  const BATCH_SIZE = 500;
+  let processedRows = 0, insertedOrUpdated = 0, deletedCount = 0;
+  const skippedRows = [];
+  const deleteKeys = new Set();
+  const csvKeys = new Set();
+  const keyColumns = ['Service Dates', 'Med Rec #', 'Invoice Num'];
+  let minDate = null, maxDate = null;
+
+  await ensureBilledArAgingConstraint();
+
+  const result = await client.query(`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = $1 AND is_generated = 'NEVER'
+    ORDER BY ordinal_position
+  `, [tableName]);
+
+  const allColumns = result.rows.map(r => r.column_name);
+  const tableColumns = allColumns.filter(c => !keyColumns.includes(c));
+  const dateColumn = allColumns.find(c => /bill\s*date/i.test(c)) || allColumns.find(c => /date/i.test(c));
+
+  await client.query('BEGIN');
+
+  try {
+    let batch = [];
+    const parser = fs.createReadStream(filePath).pipe(parse(CSV_OPTS_TOLERANT));
+
+    for await (const row of parser) {
+      processedRows++;
+      const keys = keyColumns.map(k => row[k]);
+      const action = (row['Action'] || '').toUpperCase();
+      const dateStr = dateColumn ? row[dateColumn] : null;
+      if (dateStr) {
+        const d = new Date(dateStr);
+        if (!isNaN(d)) {
+          if (!minDate || d < minDate) minDate = d;
+          if (!maxDate || d > maxDate) maxDate = d;
+        }
+      }
+
+      if (keys.some(v => !v)) {
+        skippedRows.push({ row, reason: 'Missing key columns' });
+        continue;
+      }
+
+      const composite = keys.join('|');
+      csvKeys.add(composite);
+
+      if (action === 'DELETE') {
+        deleteKeys.add(composite);
+        continue;
+      }
+
+      const rowData = tableColumns.map(c => toNullIfEmpty(row[c]));
+      batch.push({ keys, rowData });
+      if (batch.length >= BATCH_SIZE) {
+        await processBatch(batch, tableName, tableColumns, keyColumns);
+        insertedOrUpdated += batch.length;
+        batch = [];
+      }
+    }
+
+    if (batch.length) {
+      await processBatch(batch, tableName, tableColumns, keyColumns);
+      insertedOrUpdated += batch.length;
+    }
+
+    const compositeExpr =
+      `COALESCE("Service Dates"::text,'') || '|' || COALESCE("Med Rec #"::text,'') || '|' || COALESCE("Invoice Num"::text,'')`;
+
+    if (deleteKeys.size) {
+      const deleteRes = await client.query(
+        `DELETE FROM "${tableName}" WHERE ${compositeExpr} = ANY($1)`,
+        [Array.from(deleteKeys)]
+      );
+      deletedCount += deleteRes.rowCount;
+    }
+
+    if (dateColumn && minDate && maxDate && csvKeys.size) {
+      const deleteExistingRes = await client.query(
+        `DELETE FROM "${tableName}" WHERE "${dateColumn}" BETWEEN $1 AND $2 AND NOT (${compositeExpr} = ANY($3))`,
+        [minDate, maxDate, Array.from(csvKeys)]
       );
       deletedCount += deleteExistingRes.rowCount;
     }


### PR DESCRIPTION
## Summary
- add billed AR aging CSV import that upserts by Service Dates, Med Rec #, and Invoice Num
- generalize batch processing to support composite keys
- expose billed_ar_aging in upload UI

## Testing
- `node --check unified_server`
- Attempted to query database for billed_ar_aging unique constraint, but `pg` module was unavailable and installing dependencies failed with 403

------
https://chatgpt.com/codex/tasks/task_e_68b399c5e3e0832cbd7b7f730b2ca5ea