### PR TITLE
Add QueueManager CSV import utility

### DIFF
--- a/unified_server
+++ b/unified_server
@@ -509,6 +509,106 @@ async function importBilledArAging(filePath, tableName) {
   }
 }
 
+async function importQueueManager(filePath, tableName) {
+  const BATCH_SIZE = 500;
+  let processedRows = 0, insertedOrUpdated = 0, deletedCount = 0;
+  const skippedRows = [];
+  const deleteIds = new Set();
+  const csvIds = new Set();
+  let minDate = null, maxDate = null;
+
+  const result = await client.query(
+    `
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = $1 AND is_generated = 'NEVER'
+    ORDER BY ordinal_position
+    `,
+    [tableName]
+  );
+
+  const allColumns = result.rows.map(r => r.column_name);
+  const keyColumn = 'QueueID';
+  const tableColumns = allColumns.filter(c => c !== keyColumn);
+  const dateColumn = allColumns.find(c => /date/i.test(c));
+
+  await client.query('BEGIN');
+
+  try {
+    let batch = [];
+    const parser = fs.createReadStream(filePath).pipe(parse(CSV_OPTS_TOLERANT));
+
+    for await (const row of parser) {
+      processedRows++;
+      const id = row[keyColumn];
+      const action = (row['Action'] || '').toUpperCase();
+      const dateStr = dateColumn ? row[dateColumn] : null;
+      if (dateStr) {
+        const d = new Date(dateStr);
+        if (!isNaN(d)) {
+          if (!minDate || d < minDate) minDate = d;
+          if (!maxDate || d > maxDate) maxDate = d;
+        }
+      }
+
+      if (!id) {
+        skippedRows.push({ row, reason: 'Missing key column' });
+        continue;
+      }
+
+      csvIds.add(id);
+
+      if (action === 'DELETE') {
+        deleteIds.add(id);
+        continue;
+      }
+
+      const rowData = tableColumns.map(c => toNullIfEmpty(row[c]));
+      batch.push({ keys: [id], rowData });
+      if (batch.length >= BATCH_SIZE) {
+        await processBatch(batch, tableName, tableColumns, [keyColumn]);
+        insertedOrUpdated += batch.length;
+        batch = [];
+      }
+    }
+
+    if (batch.length) {
+      await processBatch(batch, tableName, tableColumns, [keyColumn]);
+      insertedOrUpdated += batch.length;
+    }
+
+    if (deleteIds.size) {
+      const deleteRes = await client.query(
+        `DELETE FROM "${tableName}" WHERE "${keyColumn}" = ANY($1)`,
+        [Array.from(deleteIds)]
+      );
+      deletedCount += deleteRes.rowCount;
+    }
+
+    if (dateColumn && minDate && maxDate && csvIds.size) {
+      const deleteExistingRes = await client.query(
+        `DELETE FROM "${tableName}" WHERE "${dateColumn}" BETWEEN $1 AND $2 AND NOT ("${keyColumn}" = ANY($3))`,
+        [minDate, maxDate, Array.from(csvIds)]
+      );
+      deletedCount += deleteExistingRes.rowCount;
+    }
+
+    await client.query('COMMIT');
+    fs.unlinkSync(filePath);
+
+    return {
+      processedRows,
+      insertedOrUpdated,
+      deletedCount,
+      skippedRows: skippedRows.length,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    throw err;
+  }
+}
+
 // ------------------ ROOT ------------------
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));


### PR DESCRIPTION
## Summary
- add `importQueueManager` to parse CSV, update `QueueID` rows, and handle deletions with optional date-range cleanup

## Testing
- `node --check unified_server`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a57cad30832c9e8e2f9ebcc877e4