### PR TITLE
Add queue_manager import branch

### DIFF
--- a/unified_server
+++ b/unified_server
@@ -107,6 +107,15 @@ app.post('/upload', upload.single('csvfile'), async (req, res) => {
         Deleted Rows: ${summary.deletedCount}
         Skipped Rows: ${summary.skippedRows}
       `);
+    } else if (tableName === 'queue_manager') {
+      const summary = await importQueueManager(filePath, tableName);
+      return res.send(`
+        ✅ QueueManager Done!
+        Processed Rows: ${summary.processedRows}
+        Inserted/Updated: ${summary.insertedOrUpdated}
+        Deleted Rows: ${summary.deletedCount}
+        Skipped Rows: ${summary.skippedRows}
+      `);
     } else {
       fs.unlinkSync(filePath);
       return res.status(400).send('❌ Unknown table selected.');


### PR DESCRIPTION
## Summary
- handle `queue_manager` uploads by invoking `importQueueManager`
- return success message with processing summary like other branches

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a69cae48832cba4c92986a39a5f6